### PR TITLE
add exchange rate test

### DIFF
--- a/practice-app/.env
+++ b/practice-app/.env
@@ -1,4 +1,3 @@
-
 DB_HOST=ds149706.mlab.com
 DB_PORT=49706
 DB_NAME=bounswe2019

--- a/practice-app/.env
+++ b/practice-app/.env
@@ -1,8 +1,10 @@
-DB_HOST=ds149706.mlab.com
-DB_PORT=49706
-DB_NAME=bounswe2019
+DB_HOST=bounswe-api-2019-gpl9e.mongodb.net
 DB_USER=api
-DB_PASS=bounswe-api-2019
+DB_PASS=uzoh6YacNjEwLtr9
+
+TEST_DB_HOST=bounswe-test-ovfdg.mongodb.net
+TEST_DB_USER=test
+TEST_DB_PASS=GCpytEpdgDLymKkV
 
 PORT=3000
 

--- a/practice-app/README.md
+++ b/practice-app/README.md
@@ -1,6 +1,9 @@
-A small express app skeleton
+To start the server
 
-Remember to run `npm install`
+- Run `npm install` to install required packages.
+- Then, run `npm run start` to start the server
+- To test, run `npm run test`
+
 
 # API
 

--- a/practice-app/helpers/db.js
+++ b/practice-app/helpers/db.js
@@ -7,10 +7,10 @@ exports.connect = () => {
   const pass = process.env.DB_PASS;
   const name = process.env.DB_NAME;
 
-  const url = `mongodb://${user}:${pass}@${host}:${port}/${name}`
+  const url = `mongodb://${user}:${pass}@${host}:${port}/${name}`;
 
-  console.log(url)
+  console.log(url);
 
-  mongoose.connect(`${url}`);
+  mongoose.connect(`${url}`, {useNewUrlParser: true, useCreateIndex: true});
   return mongoose.connection;
 };

--- a/practice-app/helpers/db.js
+++ b/practice-app/helpers/db.js
@@ -1,13 +1,21 @@
 const mongoose = require('mongoose');
 
 exports.connect = () => {
-  const host = process.env.DB_HOST;
-  const user = process.env.DB_USER;
-  const pass = process.env.DB_PASS;
+    let host, user, pass;
 
-  const url = `mongodb+srv://${user}:${pass}@${host}/test?retryWrites=true`;
-  console.log(url);
+    if (process.env.NODE_ENV === 'test') {
+      host = process.env.TEST_DB_HOST;
+      user = process.env.TEST_DB_USER;
+      pass = process.env.TEST_DB_PASS;
+    } else {
+      host = process.env.DB_HOST;
+      user = process.env.DB_USER;
+      pass = process.env.DB_PASS;
+    }
 
-  mongoose.connect(`${url}`, {useNewUrlParser: true, useCreateIndex: true});
-  return mongoose.connection;
+    const url = `mongodb+srv://${user}:${pass}@${host}/test?retryWrites=true`;
+    console.log(url);
+
+    mongoose.connect(`${url}`, {useNewUrlParser: true, useCreateIndex: true});
+    return mongoose.connection;
 };

--- a/practice-app/helpers/db.js
+++ b/practice-app/helpers/db.js
@@ -2,15 +2,14 @@ const mongoose = require('mongoose');
 
 exports.connect = () => {
     let host, user, pass;
-
     if (process.env.NODE_ENV === 'test') {
-      host = process.env.TEST_DB_HOST;
-      user = process.env.TEST_DB_USER;
-      pass = process.env.TEST_DB_PASS;
+        host = process.env.TEST_DB_HOST;
+        user = process.env.TEST_DB_USER;
+        pass = process.env.TEST_DB_PASS;
     } else {
-      host = process.env.DB_HOST;
-      user = process.env.DB_USER;
-      pass = process.env.DB_PASS;
+        host = process.env.DB_HOST;
+        user = process.env.DB_USER;
+        pass = process.env.DB_PASS;
     }
 
     const url = `mongodb+srv://${user}:${pass}@${host}/test?retryWrites=true`;

--- a/practice-app/helpers/db.js
+++ b/practice-app/helpers/db.js
@@ -2,13 +2,10 @@ const mongoose = require('mongoose');
 
 exports.connect = () => {
   const host = process.env.DB_HOST;
-  const port = process.env.DB_PORT;
   const user = process.env.DB_USER;
   const pass = process.env.DB_PASS;
-  const name = process.env.DB_NAME;
 
-  const url = `mongodb://${user}:${pass}@${host}:${port}/${name}`;
-
+  const url = `mongodb+srv://${user}:${pass}@${host}/test?retryWrites=true`;
   console.log(url);
 
   mongoose.connect(`${url}`, {useNewUrlParser: true, useCreateIndex: true});

--- a/practice-app/index.js
+++ b/practice-app/index.js
@@ -1,13 +1,12 @@
+require('dotenv').config({path: __dirname + '/.env'});
+
 const express = require('express');
 const bodyParser = require('body-parser');
-const dotenv = require('dotenv');
 const app = express();
 const port = process.env.PORT || 3000;
-// Load the variables in .env file to the process.env
-dotenv.config();
-
 const db = require('./helpers/db');
-db.connect()
+db
+    .connect()
     .on('error', console.error)
     .on('disconnected', db.connect)
     .once('open', () => {
@@ -20,7 +19,7 @@ app.use(bodyParser.json({
 }));
 
 app.set('view engine', 'pug');
-app.set('views', './views');
+app.set('views', __dirname + '/views');
 
 app.use(express.static('static'));
 app.use(express.urlencoded({extended: true}));
@@ -35,3 +34,5 @@ app.get("/", (req, res) => {
 });
 
 app.listen(port, () => console.log(`Started on port ${port}`));
+
+module.exports = app; // for testing

--- a/practice-app/index.js
+++ b/practice-app/index.js
@@ -7,17 +7,16 @@ const port = process.env.PORT || 3000;
 dotenv.config();
 
 const db = require('./helpers/db');
-db
-  .connect()
-  .on('error', console.error)
-  .on('disconnected', db.connect)
-  .once('open', () => {
-      console.log("Database connected");
+db.connect()
+    .on('error', console.error)
+    .on('disconnected', db.connect)
+    .once('open', () => {
+        console.log("Database connected");
 });
 
 app.use(bodyParser.text());
 app.use(bodyParser.json({
-  type: 'application/json'
+    type: 'application/json'
 }));
 
 app.set('view engine', 'pug');
@@ -32,7 +31,7 @@ app.use('/api/exchangerate', require('./routes/exchange_rate_api'));
 app.use('/register', require('./routes/register'))
 
 app.get("/", (req, res) => {
-  res.render('home');
+    res.render('home');
 });
 
 app.listen(port, () => console.log(`Started on port ${port}`));

--- a/practice-app/index.js
+++ b/practice-app/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const dotenv = require('dotenv');
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000;
 // Load the variables in .env file to the process.env
 dotenv.config();
 
@@ -12,7 +12,7 @@ db
   .on('error', console.error)
   .on('disconnected', db.connect)
   .once('open', () => {
-      console.log("Database connected")
+      console.log("Database connected");
 });
 
 app.use(bodyParser.text());
@@ -36,4 +36,3 @@ app.get("/", (req, res) => {
 });
 
 app.listen(port, () => console.log(`Started on port ${port}`));
-

--- a/practice-app/package.json
+++ b/practice-app/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "SET NODE_ENV=prod && node index.js",
-    "test": "SET NODE_ENV=test && mocha --timeout 10000"
+    "test": "SET NODE_ENV=test && mocha --timeout 10000 --exit"
   },
   "author": "",
   "license": "ISC",

--- a/practice-app/package.json
+++ b/practice-app/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "SET NODE_ENV=prod && node index.js",
+    "test": "SET NODE_ENV=test && mocha --timeout 10000"
   },
   "author": "",
   "license": "ISC",
@@ -17,5 +17,10 @@
     "mongoose": "^5.5.5",
     "pug": "^2.0.3",
     "request": "^2.88.0"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "chai-http": "^4.3.0",
+    "mocha": "^6.1.4"
   }
 }

--- a/practice-app/routes/exchange_rate_api.js
+++ b/practice-app/routes/exchange_rate_api.js
@@ -11,7 +11,7 @@ router.get('/', (req, res) => {
     let from = req.query.from || 'TRY';
     let to = req.query.to;
 
-    if (to == null) {
+    if (to == null || to === '') {
         res.status(400).send({
             'error': '\'to\' parameter cannot be empty!'
         });
@@ -47,7 +47,7 @@ function sendRequestToEndpoint(res, from, to) {
         } else if (response.statusCode !== 200) {
             // If the endpoint returns an error code (like invalid from/to symbols)
             // send it directly to the user
-            res.status(400).send(body);
+            res.status(400).send(JSON.parse(body));
         } else {
             // Parse the result. Update the DB and send the result to the user
             const result = JSON.parse(body);

--- a/practice-app/test/exchange_rate_api_test.js
+++ b/practice-app/test/exchange_rate_api_test.js
@@ -1,0 +1,87 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../index');
+const should = chai.should();
+
+chai.use(chaiHttp);
+
+describe('Exchange rate api test', () => {
+    const api_url = '/api/exchangerate';
+
+    it('should get /api/exchangerate with from and to parameters', (done) => {
+        const from = 'USD';
+        const to = 'EUR';
+
+        chai.request(server)
+            .get(api_url + `?from=${from}&to=${to}`)
+            .end((err, res) => {
+                res.should.have.status(200);
+                res.body.should.be.a('object');
+                res.body.should.have.property('from');
+                res.body.from.should.be.equal(from);
+                res.body.should.have.property('to');
+                res.body.to.should.have.property(to);
+                done();
+            });
+    });
+
+    it('should get /api/exchangerate with just to parameter', (done) => {
+       const to = 'EUR';
+
+       chai.request(server)
+           .get(api_url + `?to=${to}`)
+           .end((err, res) => {
+              res.should.have.status(200);
+              res.body.should.be.a('object');
+              res.body.should.have.property('from');
+              res.body.from.should.be.equal('TRY');
+              res.body.should.have.property('to');
+              res.body.to.should.have.property(to);
+              done();
+           });
+    });
+
+    it('should get /api/exchangerate with no parameters fail', (done) => {
+        chai.request(server)
+            .get(api_url)
+            .end((err, res) => {
+                res.should.have.status(400);
+                res.body.should.have.property('error');
+                res.body.error.should.be.equal('\'to\' parameter cannot be empty!');
+                done();
+            });
+    });
+
+    it('should get /api/exchangerate with empty parameters fail', (done) => {
+        chai.request(server)
+            .get(api_url + '?from=&to=')
+            .end((err, res) => {
+                res.should.have.status(400);
+                res.body.should.have.property('error');
+                res.body.error.should.be.equal('\'to\' parameter cannot be empty!');
+                done();
+            });
+    });
+
+    it('should get /api/exchangerate with just from parameter fail', (done) => {
+        chai.request(server)
+            .get(api_url + '?from=USD')
+            .end((err, res) => {
+                res.should.have.status(400);
+                res.body.should.have.property('error');
+                res.body.error.should.be.equal('\'to\' parameter cannot be empty!');
+                done();
+            });
+    });
+
+    it('should get /api/exchangerate with invalid symbols fail', (done) => {
+        chai.request(server)
+            .get(api_url + '?from=INVA&to=LID')
+            .end((err, res) => {
+                res.should.have.status(400);
+                res.body.should.have.property('error');
+                res.body.error.should.be.equal('Base \'INVA\' is not supported.');
+                done();
+            });
+    });
+});

--- a/practice-app/test/exchange_rate_test.js
+++ b/practice-app/test/exchange_rate_test.js
@@ -1,3 +1,5 @@
+process.env.NODE_ENV = 'test';
+
 const chai = require('chai');
 const chaiHttp = require('chai-http');
 const server = require('../index');

--- a/practice-app/test/exchange_rate_test.js
+++ b/practice-app/test/exchange_rate_test.js
@@ -1,0 +1,19 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../index');
+const should = chai.should();
+
+chai.use(chaiHttp);
+
+describe('Exchange rate view test', () => {
+    it('should get /exchangerate', (done) => {
+        chai.request(server)
+            .get('/exchangerate')
+            .end((err, res) => {
+                res.should.have.status(200);
+                res.should.have.property('text');
+                res.text.should.have.string('<option value="TRY">Turkey Lira</option>');
+                done();
+            });
+    });
+});


### PR DESCRIPTION
a couple of changes are made

- db provider is changed from mlab to mongo atlas. mlab was sometimes failing. mongo atlas is much more consistent.
- two new parameters are passed to mongoose.connect function to get rid of the deprecation warnings.
- now, the db to connect is choosed at runtime according to NODE_ENV variable. if it is set to `test`, we connect to test db, otherwise prod db
- added exchangerate view and api tests
