### PR TITLE
reject unverified users on login

### DIFF
--- a/backend/helpers/errors.js
+++ b/backend/helpers/errors.js
@@ -43,4 +43,7 @@ module.exports = {
     USER_ALREADY_VERIFIED: (cause) => {
       return PapelError('UserAlreadyVerified', 'User already verified', cause);
     },
+    USER_NOT_VERIFIED: (cause) => {
+        return PapelError('UserNotVerified', 'User not verified.', cause);
+    },
 };

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -73,7 +73,7 @@ router.post('/login', async (req, res) => {
         const response = await authService.login(email, password);
         res.status(200).send(response);
     } catch (err) {
-        if (err.name === 'InvalidCredentials') {
+        if (err.name === 'InvalidCredentials' || err.name === 'UserNotVerified') {
             res.status(401).send(err);
         } else {
             res.status(500).send(errors.INTERNAL_ERROR(err));

--- a/backend/services/auth.js
+++ b/backend/services/auth.js
@@ -74,6 +74,9 @@ module.exports.login = async (email, password) => {
     if (!isPasswordMatched) {
         throw errors.INVALID_CREDENTIALS();
     }
+    if (!user.isVerified) {
+        throw errors.USER_NOT_VERIFIED();
+    }
     delete user.password;
     const token = generateJwtToken(user._id);
     return {


### PR DESCRIPTION
Users were able to login even though they did not complete their registrations using the verification link that is sent to their email. This PR fixes that and sends `UserNotVerified` error in that case.

fixes #144 