### PR TITLE
add missing match stage to the get comments pipeline

### DIFF
--- a/backend/services/article.js
+++ b/backend/services/article.js
@@ -41,6 +41,13 @@ const STAGES = {
             },
             pipeline: [
                 {
+                  $match: {
+                      $expr: {
+                          $eq: ['$$articleId', '$articleId']
+                      }
+                  }
+                },
+                {
                     $lookup: {
                         from: 'users',
                         let: {


### PR DESCRIPTION
I forget to add the match stage to the get comments pipeline so we were returning all the comments. This is fixed now.