### PR TITLE
Implement predictions for currencies

### DIFF
--- a/backend/helpers/errors.js
+++ b/backend/helpers/errors.js
@@ -64,9 +64,6 @@ module.exports = {
     STOCK_NOT_FOUND: (cause) => {
         return PapelError('StockNotFound', 'Stock not found.', cause);
     },
-    CURRENCY_NOT_FOUND: (cause) => {
-        return PapelError('CurrencyNotFound', 'Currency not found.', cause);
-    },
     ARTICLE_NOT_FOUND: (cause) => {
       return PapelError('ArticleNotFound', 'Article with the given id is not found.', cause);
     },

--- a/backend/helpers/prediction.js
+++ b/backend/helpers/prediction.js
@@ -2,3 +2,8 @@ module.exports.EQUIPMENT_TYPE = {
     CURRENCY: 0,
     STOCK: 1,
 };
+
+module.exports.PREDICTION = {
+  INCREASE: 1,
+  DECREASE: -1,
+};

--- a/backend/helpers/prediction.js
+++ b/backend/helpers/prediction.js
@@ -1,0 +1,4 @@
+module.exports.EQUIPMENT_TYPE = {
+    CURRENCY: 0,
+    STOCK: 1,
+};

--- a/backend/jobs/jobs.js
+++ b/backend/jobs/jobs.js
@@ -122,6 +122,7 @@ const predictionJob = new CronJob('00 00 00 * * *', async () => {
                         .findOne({code: currencyCode})
                         .select('rate -_id')
                         .exec();
+                    currentRate = currentRate.rate;
                     currencyCache.set(currencyCode, currentRate);
                 }
                 if (prediction.snapshot <= currentRate && prediction.prediction === 1) {

--- a/backend/jobs/jobs.js
+++ b/backend/jobs/jobs.js
@@ -125,7 +125,7 @@ const predictionJob = new CronJob('00 00 00 * * *', async () => {
                     currentRate = currentRate.rate;
                     currencyCache.set(currencyCode, currentRate);
                 }
-                if (prediction.snapshot <= currentRate && prediction.prediction === 1) {
+                if (prediction.snapshot <= currentRate && prediction.prediction === predictionHelper.PREDICTION.INCREASE) {
                     await User.findOneAndUpdate({_id: prediction.userId}, {
                         $inc: {
                             totalPredictionCount: 1,

--- a/backend/models/currencyComment.js
+++ b/backend/models/currencyComment.js
@@ -1,10 +1,9 @@
 const mongoose = require('mongoose');
 
 const currencyCommentSchema = new mongoose.Schema({
-    currencyId: {
-      type: mongoose.Schema.Types.ObjectId,
+    currencyCode: {
+      type: String,
       required: true,
-      ref: 'Currency',
     },
     authorId: {
         type: mongoose.Schema.Types.ObjectId,

--- a/backend/models/prediction.js
+++ b/backend/models/prediction.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const EQUIPMENT_TYPE = require('../helpers/prediction').EQUIPMENT_TYPE;
+const PREDICTION = require('../helpers/prediction').PREDICTION;
 
 const predictionSchema = new mongoose.Schema({
     userId: {
@@ -26,7 +27,7 @@ const predictionSchema = new mongoose.Schema({
     prediction: {
         type: Number,
         required: true,
-        enum: [-1, 1]
+        enum: [PREDICTION.DECREASE, PREDICTION.DECREASE],
     }
 });
 

--- a/backend/models/prediction.js
+++ b/backend/models/prediction.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const EQUIPMENT_TYPE = require('../helpers/prediction').EQUIPMENT_TYPE;
 
 const predictionSchema = new mongoose.Schema({
     userId: {
@@ -6,9 +7,8 @@ const predictionSchema = new mongoose.Schema({
         required: true,
         ref: 'User'
     },
-    currencyId: {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Currency',
+    currencyCode: {
+        type: String,
     },
     stockId: {
         type: mongoose.Schema.Types.ObjectId,
@@ -17,7 +17,7 @@ const predictionSchema = new mongoose.Schema({
     equipmentType: {
         type: Number,
         required: true,
-        enum: [0, 1], // 0 for currency, 1 for stock
+        enum: [EQUIPMENT_TYPE.CURRENCY, EQUIPMENT_TYPE.STOCK],
     },
     snapshot: {
         type: Number,

--- a/backend/models/prediction.js
+++ b/backend/models/prediction.js
@@ -1,0 +1,34 @@
+const mongoose = require('mongoose');
+
+const predictionSchema = new mongoose.Schema({
+    userId: {
+        type: mongoose.Schema.Types.ObjectId,
+        required: true,
+        ref: 'User'
+    },
+    currencyId: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Currency',
+    },
+    stockId: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Stock',
+    },
+    equipmentType: {
+        type: Number,
+        required: true,
+        enum: [0, 1], // 0 for currency, 1 for stock
+    },
+    snapshot: {
+        type: Number,
+        required: true,
+    },
+    prediction: {
+        type: Number,
+        required: true,
+        enum: [-1, 1]
+    }
+});
+
+const Prediction = mongoose.model('Prediction', predictionSchema);
+module.exports = Prediction;

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -108,7 +108,14 @@ const userSchema = new mongoose.Schema({
         enum: ['public','private'],
         default: 'public'
     },
-
+    totalPredictionCount: {
+        type: Number,
+        default: 0,
+    },
+    successfulPredictionCount: {
+        type: Number,
+        default: 0,
+    }
 });
 
 userSchema.pre('save', async function (next) {

--- a/backend/routes/currency.js
+++ b/backend/routes/currency.js
@@ -143,16 +143,16 @@ router.get('/:code/full', async (req, res) => {
     }
 });
 
-/*
-router.post('/:id/comment', isAuthenticated, async (req, res) => {
+
+router.post('/:code/comment', isAuthenticated, async (req, res) => {
     try {
-        const currencyId = req.params.id;
+        const code = req.params.code;
         const userId = req.token && req.token.data && req.token.data._id;
         const body = req.body.body;
-        await currencyService.postComment(currencyId, userId, body);
+        await currencyService.postComment(code, userId, body);
         res.sendStatus(200);
     } catch (err) {
-        if (err.name === 'CurrencyNotFound') {
+        if (err.name === 'InvalidCurrencyCode') {
             res.status(400).send(err);
         } else if (err.name === 'UserNotFound') {
             res.status(400).send(err);
@@ -172,16 +172,16 @@ router.post('/:id/comment', isAuthenticated, async (req, res) => {
     }
 });
 
-router.get('/:id/comment/:commentId', async (req, res) => {
+router.get('/:code/comment/:commentId', async (req, res) => {
     try {
-        const currencyId = req.params.id;
+        const code = req.params.id;
         const commentId = req.params.commentId;
-        const comment = await currencykService.getComment(currencyId, commentId);
+        const comment = await currencyService.getComment(code, commentId);
         res.status(200).send(comment);
     } catch (err) {
         if (err.name === 'CommentNotFound') {
             res.status(400).send(err);
-        } else if (err.name === 'CurrencyNotFound') {
+        } else if (err.name === 'InvalidCurrencyCode') {
             res.status(400).send(err);
         } else {
             res.status(500).send(errors.INTERNAL_ERROR(err));
@@ -189,16 +189,16 @@ router.get('/:id/comment/:commentId', async (req, res) => {
     }
 });
 
-router.post('/:id/comment/:commentId', isAuthenticated, async (req, res) => {
+router.post('/:code/comment/:commentId', isAuthenticated, async (req, res) => {
     try {
-        const currencyId = req.params.id;
+        const code = req.params.id;
         const authorId = req.token && req.token.data && req.token.data._id;
         const commentId = req.params.commentId;
         const newBody = req.body.body;
-        await currencyService.editComment(currencyId, authorId, commentId, newBody);
+        await currencyService.editComment(code, authorId, commentId, newBody);
         res.sendStatus(200);
     } catch (err) {
-        if (err.name === 'CurrencyNotFound') {
+        if (err.name === 'InvalidCurrencyCode') {
             res.status(400).send(err);
         } else if (err.name === 'CommentNotFound') {
             res.status(400).send(err);
@@ -220,15 +220,15 @@ router.post('/:id/comment/:commentId', isAuthenticated, async (req, res) => {
     }
 });
 
-router.delete('/:id/comment/:commentId', isAuthenticated, async (req, res) => {
+router.delete('/:code/comment/:commentId', isAuthenticated, async (req, res) => {
     try {
-        const currencyId = req.params.id;
+        const code = req.params.id;
         const commentId = req.params.commentId;
         const userId = req.token && req.token.data && req.token.data._id;
-        await currencyService.deleteComment(currencyId, commentId, userId);
+        await currencyService.deleteComment(code, commentId, userId);
         res.sendStatus(200);
     } catch (err) {
-        if (err.name === 'CurrencykNotFound') {
+        if (err.name === 'InvalidCurrencyCode') {
             res.status(400).send(err);
         } else if (err.name === 'CommentNotFound') {
             res.status(400).send(err);
@@ -239,6 +239,5 @@ router.delete('/:id/comment/:commentId', isAuthenticated, async (req, res) => {
         }
     }
 });
-*/
 
 module.exports = router;

--- a/backend/routes/currency.js
+++ b/backend/routes/currency.js
@@ -42,6 +42,21 @@ router.post('/:code/predict-increase', isAuthenticated, async (req, res) => {
     }
 });
 
+router.post('/:code/predict-decrease', isAuthenticated, async (req, res) => {
+    try {
+        const code = req.params.code;
+        const userId = req.token && req.token.data && req.token.data._id;
+        await currencyService.predict(code, userId, -1);
+        res.sendStatus(200);
+    } catch (err) {
+        if (err.name === 'InvalidCurrencyCode') {
+            res.status(400).send(err);
+        } else {
+            res.status(500).send(errors.INTERNAL_ERROR(err));
+        }
+    }
+});
+
 router.get('/:code/intraday', async (req, res) => {
     try {
         const code = req.params.code;

--- a/backend/routes/currency.js
+++ b/backend/routes/currency.js
@@ -3,6 +3,7 @@ const currencyService = require('../services/currency');
 const errors = require('../helpers/errors');
 const isAuthenticated = require('../middlewares/isAuthenticated');
 const router = express.Router();
+const predictionHelper = require('../helpers/prediction');
 
 router.get('/', async (req, res) => {
     try {
@@ -31,7 +32,7 @@ router.post('/:code/predict-increase', isAuthenticated, async (req, res) => {
     try {
         const code = req.params.code;
         const userId = req.token && req.token.data && req.token.data._id;
-        await currencyService.predict(code, userId, 1);
+        await currencyService.predict(code, userId, predictionHelper.PREDICTION.INCREASE);
         res.sendStatus(200);
     } catch (err) {
         if (err.name === 'InvalidCurrencyCode') {
@@ -46,7 +47,7 @@ router.post('/:code/predict-decrease', isAuthenticated, async (req, res) => {
     try {
         const code = req.params.code;
         const userId = req.token && req.token.data && req.token.data._id;
-        await currencyService.predict(code, userId, -1);
+        await currencyService.predict(code, userId, predictionHelper.PREDICTION.DECREASE);
         res.sendStatus(200);
     } catch (err) {
         if (err.name === 'InvalidCurrencyCode') {

--- a/backend/routes/currency.js
+++ b/backend/routes/currency.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const currencyService = require('../services/currency');
 const errors = require('../helpers/errors');
+const isAuthenticated = require('../middlewares/isAuthenticated');
 const router = express.Router();
 
 router.get('/', async (req, res) => {
@@ -17,6 +18,21 @@ router.get('/:code', async (req, res) => {
         const code = req.params.code;
         const response = await currencyService.get(code);
         res.status(200).send(response);
+    } catch (err) {
+        if (err.name === 'InvalidCurrencyCode') {
+            res.status(400).send(err);
+        } else {
+            res.status(500).send(errors.INTERNAL_ERROR(err));
+        }
+    }
+});
+
+router.post('/:code/predict-increase', isAuthenticated, async (req, res) => {
+    try {
+        const code = req.params.code;
+        const userId = req.token && req.token.data && req.token.data._id;
+        await currencyService.predict(code, userId, 1);
+        res.sendStatus(200);
     } catch (err) {
         if (err.name === 'InvalidCurrencyCode') {
             res.status(400).send(err);

--- a/backend/routes/currency.js
+++ b/backend/routes/currency.js
@@ -4,6 +4,7 @@ const errors = require('../helpers/errors');
 const isAuthenticated = require('../middlewares/isAuthenticated');
 const router = express.Router();
 const predictionHelper = require('../helpers/prediction');
+const authHelper = require('../helpers/auth');
 
 router.get('/', async (req, res) => {
     try {
@@ -17,7 +18,8 @@ router.get('/', async (req, res) => {
 router.get('/:code', async (req, res) => {
     try {
         const code = req.params.code;
-        const response = await currencyService.get(code);
+        const userId = authHelper.getUserIdOrNull(req);
+        const response = await currencyService.get(code, userId);
         res.status(200).send(response);
     } catch (err) {
         if (err.name === 'InvalidCurrencyCode') {

--- a/backend/routes/currency.js
+++ b/backend/routes/currency.js
@@ -174,7 +174,7 @@ router.post('/:code/comment', isAuthenticated, async (req, res) => {
 
 router.get('/:code/comment/:commentId', async (req, res) => {
     try {
-        const code = req.params.id;
+        const code = req.params.code;
         const commentId = req.params.commentId;
         const comment = await currencyService.getComment(code, commentId);
         res.status(200).send(comment);
@@ -191,7 +191,7 @@ router.get('/:code/comment/:commentId', async (req, res) => {
 
 router.post('/:code/comment/:commentId', isAuthenticated, async (req, res) => {
     try {
-        const code = req.params.id;
+        const code = req.params.code;
         const authorId = req.token && req.token.data && req.token.data._id;
         const commentId = req.params.commentId;
         const newBody = req.body.body;
@@ -222,7 +222,7 @@ router.post('/:code/comment/:commentId', isAuthenticated, async (req, res) => {
 
 router.delete('/:code/comment/:commentId', isAuthenticated, async (req, res) => {
     try {
-        const code = req.params.id;
+        const code = req.params.code;
         const commentId = req.params.commentId;
         const userId = req.token && req.token.data && req.token.data._id;
         await currencyService.deleteComment(code, commentId, userId);

--- a/backend/routes/currency.js
+++ b/backend/routes/currency.js
@@ -57,6 +57,21 @@ router.post('/:code/predict-decrease', isAuthenticated, async (req, res) => {
     }
 });
 
+router.post('/:code/clear-prediction', isAuthenticated, async (req, res) => {
+    try {
+        const code = req.params.code;
+        const userId = req.token && req.token.data && req.token.data._id;
+        await currencyService.clearPrediction(code, userId);
+        res.sendStatus(200);
+    } catch (err) {
+        if (err.name === 'InvalidCurrencyCode') {
+            res.status(400).send(err);
+        } else {
+            res.status(500).send(errors.INTERNAL_ERROR(err));
+        }
+    }
+});
+
 router.get('/:code/intraday', async (req, res) => {
     try {
         const code = req.params.code;

--- a/backend/services/currency.js
+++ b/backend/services/currency.js
@@ -47,7 +47,7 @@ const STAGES = {
                 },
                 {
                     $project: {
-                        code: 0
+                        currencyCode: 0
                     }
                 }
             ],

--- a/backend/services/currency.js
+++ b/backend/services/currency.js
@@ -199,7 +199,7 @@ module.exports.predict = async (code, userId, prediction) => {
     currentRate = currentRate.rate;
     await Prediction.updateOne(
         {userId, currencyCode: code, equipmentType: predictionHelper.EQUIPMENT_TYPE.CURRENCY},
-        {snapShot: currentRate, prediction},
+        {snapshot: currentRate, prediction},
         {upsert: true});
 };
 

--- a/backend/services/currency.js
+++ b/backend/services/currency.js
@@ -191,13 +191,19 @@ module.exports.predict = async (code, userId, prediction) => {
         .select('rate -_id')
         .exec();
     currentRate = currentRate.rate;
-    await Prediction.create({
-        userId,
-        currencyCode: code,
-        equipmentType: predictionHelper.EQUIPMENT_TYPE.CURRENCY,
-        snapshot: currentRate,
-        prediction
-    });
+    await Prediction.updateOne(
+        {userId, currencyCode: code, equipmentType: predictionHelper.EQUIPMENT_TYPE.CURRENCY},
+        {snapShot: currentRate, prediction},
+        {upsert: true});
+};
+
+module.exports.clearPrediction = async (code, userId) => {
+    code = code.toUpperCase();
+    if (!SUPPORTED_CURRENCIES.has(code)) {
+        throw errors.INVALID_CURRENCY_CODE();
+    }
+
+    await Prediction.deleteOne({userId, currencyCode: code, equipmentType: predictionHelper.EQUIPMENT_TYPE.CURRENCY});
 };
 
 /*

--- a/backend/services/currency.js
+++ b/backend/services/currency.js
@@ -2,6 +2,8 @@ const Currency = require('../models/currency');
 const errors = require('../helpers/errors');
 const CurrencyComment = require('../models/currencyComment');
 const mongoose = require('mongoose');
+const Prediction = require('../models/prediction');
+const predictionHelper = require('../helpers/prediction');
 
 const STAGES = {
     GET_COMMENTS: {
@@ -176,6 +178,26 @@ module.exports.getLastFull = async (code) => {
         .findOne({code})
         .select('-__v -_id')
         .exec();
+};
+
+module.exports.predict = async (code, userId, prediction) => {
+    code = code.toUpperCase();
+    if (!SUPPORTED_CURRENCIES.has(code)) {
+        throw errors.INVALID_CURRENCY_CODE();
+    }
+
+    let currentRate = await Currency
+        .findOne({code})
+        .select('rate -_id')
+        .exec();
+    currentRate = currentRate.rate;
+    await Prediction.create({
+        userId,
+        currencyCode: code,
+        equipmentType: predictionHelper.EQUIPMENT_TYPE.CURRENCY,
+        snapshot: currentRate,
+        prediction
+    });
 };
 
 /*

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -1854,6 +1854,207 @@
           }
         }
       }
+    },
+    "/currency/{code}/comment": {
+      "post": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "currency"
+        ],
+        "summary": "Endpoint to add a comment to a currency.",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "comment",
+            "description": "Comment to be added.",
+            "schema": {
+              "type": "object",
+              "required": [
+                "body"
+              ],
+              "properties": {
+                "body": {
+                  "type": "string",
+                  "description": "Body of the comment.",
+                  "example": "That's not even remotely funny."
+                }
+              }
+            }
+          },
+          {
+            "in": "path",
+            "name": "code",
+            "description": "Code of the currency.",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. Comment successfully added."
+          },
+          "400": {
+            "description": "Validation error. The body of the comment may be missing or the currency with the given code not found. Check causes field for diagnostics."
+          },
+          "401": {
+            "description": "Authorization token was missing, invalid or expired."
+          },
+          "500": {
+            "description": "Internal error occurred. Check the cause field for the diagnostics."
+          }
+        }
+      }
+    },
+    "/currency/{code}/comment/{commentId}": {
+      "get": {
+        "tags": [
+          "currency"
+        ],
+        "summary": "Endpoint that returns the selected comment.",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "description": "Code of the currency",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "commentId",
+            "description": "Id of the comment",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. Comment returned.",
+            "schema": {
+              "$ref": "#/definitions/Comment"
+            }
+          },
+          "400": {
+            "description": "Validation error. Either the comment or the currency not found."
+          },
+          "500": {
+            "description": "Internal error occurred. Check the cause field for the diagnostics."
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "currency"
+        ],
+        "summary": "Endpoint that updates the selected comment.",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "description": "Code of the currency",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "commentId",
+            "description": "Id of the comment",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "body",
+            "name": "commentBody",
+            "description": "New body of the comment.",
+            "schema": {
+              "type": "object",
+              "required": [
+                "body"
+              ],
+              "properties": {
+                "body": {
+                  "type": "string",
+                  "description": "New body of the comment.",
+                  "example": "That's not even remotely funny."
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. Comment updated."
+          },
+          "400": {
+            "description": "Validation error. Either the comment or the currency not found or the body was empty."
+          },
+          "500": {
+            "description": "Internal error occurred. Check the cause field for the diagnostics."
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "currency"
+        ],
+        "summary": "Endpoint that deletes the selected comment.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "description": "Code of the currency",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "commentId",
+            "description": "Id of the comment",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. Comment deleted."
+          },
+          "400": {
+            "description": "Currency, user or the comment not found."
+          },
+          "500": {
+            "description": "Internal error occurred. Check the cause field for the diagnostics."
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -1668,7 +1668,7 @@
             "description": "OK. Given currency, its rate and comments are returned.",
             "schema": {
               "type": "object",
-              "$ref": "#/definitions/CurrencyWithComments"
+              "$ref": "#/definitions/CurrencyGet"
             }
           },
           "400": {
@@ -2617,7 +2617,7 @@
         }
       }
     },
-    "CurrencyWithComments": {
+    "CurrencyGet": {
       "allOf": [
         {
           "$ref": "#/definitions/CurrencyMinimal"
@@ -2629,6 +2629,24 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Comment"
+          }
+        },
+        "predictions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "prediction": {
+                "type": "number",
+                "description": "Prediction type (-1 for decrease, 1 for increase)",
+                "example": 1
+              },
+              "count": {
+                "type": "number",
+                "description": "Count of predictions.",
+                "example": 10
+              }
+            }
           }
         }
       }

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -2055,6 +2055,123 @@
           }
         }
       }
+    },
+    "/currency/{code}/predict-increase": {
+      "post": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "currency"
+        ],
+        "summary": "Endpoint to predict an increase on a currency.",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "description": "Code of the currency.",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. Prediction successfully made."
+          },
+          "400": {
+            "description": "Validation error. Either the currency with the given code or the user with the given token not found. Check causes field for diagnostics."
+          },
+          "401": {
+            "description": "Authorization token was missing, invalid or expired."
+          },
+          "500": {
+            "description": "Internal error occurred. Check the cause field for the diagnostics."
+          }
+        }
+      }
+    },
+    "/currency/{code}/predict-decrease": {
+      "post": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "currency"
+        ],
+        "summary": "Endpoint to predict a decrease on a currency.",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "description": "Code of the currency.",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. Prediction successfully made."
+          },
+          "400": {
+            "description": "Validation error. Either the currency with the given code or the user with the given token not found. Check causes field for diagnostics."
+          },
+          "401": {
+            "description": "Authorization token was missing, invalid or expired."
+          },
+          "500": {
+            "description": "Internal error occurred. Check the cause field for the diagnostics."
+          }
+        }
+      }
+    },
+    "/currency/{code}/clear-prediction": {
+      "post": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "currency"
+        ],
+        "summary": "Endpoint to clear prediction on a currency.",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "description": "Code of the currency.",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. Prediction for the currency successfully cleared."
+          },
+          "400": {
+            "description": "Validation error. Either the currency with the given code, the user with the given token or the vote not found. Check causes field for diagnostics."
+          },
+          "401": {
+            "description": "Authorization token was missing, invalid or expired."
+          },
+          "500": {
+            "description": "Internal error occurred. Check the cause field for the diagnostics."
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -2241,6 +2241,16 @@
           "type": "string",
           "description": "Google user id.",
           "example": "117027522423426552111"
+        },
+        "totalPredictionCount": {
+          "type": "number",
+          "description": "Number of total predictions.",
+          "example": 100
+        },
+        "successfulPredictionCount": {
+          "type": "number",
+          "description": "Number of successful predictions.",
+          "example": 10
         }
       }
     },

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "title": "Papel Backend"
   },
-  "host": "ec2-18-197-152-183.eu-central-1.compute.amazonaws.com:3000",
+  "host": "localhost:3000",
   "basePath": "/",
   "tags": [
     {
@@ -1650,7 +1650,7 @@
         "tags": [
           "currency"
         ],
-        "summary": "Returns the rate of the given currency.",
+        "summary": "Returns the rate and comments of the given currency.",
         "produces": [
           "application/json"
         ],
@@ -1665,10 +1665,10 @@
         ],
         "responses": {
           "200": {
-            "description": "OK. Given currency and its rate are returned.",
+            "description": "OK. Given currency, its rate and comments are returned.",
             "schema": {
               "type": "object",
-              "$ref": "#/definitions/CurrencyMinimal"
+              "$ref": "#/definitions/CurrencyWithComments"
             }
           },
           "400": {
@@ -2099,11 +2099,6 @@
           "description": "Id of the comment.",
           "example": "5daedb5af05eb852753ac9c0"
         },
-        "articleId": {
-          "type": "string",
-          "description": "Id of the article that the comment is posted.",
-          "example": "5daedb5af05eb852753ac9c1"
-        },
         "authorId": {
           "type": "string",
           "description": "Id of the author of this comment.",
@@ -2301,6 +2296,22 @@
           "type": "number",
           "description": "Rate of the currency to the USD",
           "example": 0.91
+        }
+      }
+    },
+    "CurrencyWithComments": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CurrencyMinimal"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "comments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
         }
       }
     },


### PR DESCRIPTION
Implemented prediction (increase or decrease) for currencies. With this feature, users can make predictions and a cron job will fire at midnight checking whether or not they correctly predicted it. If so, their `successfulPredictionCount` and `totalPredictionCount` will increase by 1, otherwise just the `totalPredictionCount` will increase. Users can also change or clear their predictions. 

Also, fixed the comments for currencies.