### PR TITLE
Add notification endpoint

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -28,6 +28,7 @@ app.use('/user', require('./routes/user'));
 app.use('/profile',require('./routes/profile'));
 app.use('/currency', require('./routes/currency'));
 app.use('/investments', require('./routes/investments'));
+app.use('/notification', require('./routes/notification'));
 
 const port = process.env.PORT;
 app.listen(port, async () => {

--- a/backend/helpers/errors.js
+++ b/backend/helpers/errors.js
@@ -97,5 +97,7 @@ module.exports = {
     INVALID_PRIVACY_OPTION: (cause) => {
         return PapelError('InvalidPrivacyOption', 'Privacy options should be either \'public\' or \'private\'', cause);
     },
-
+    NOTIFICATION_NOT_FOUND: (cause) => {
+        return PapelError('NotificationNotFound', 'Notification with the given id and user id is not found.', cause);
+    }
 };

--- a/backend/models/followNotification.js
+++ b/backend/models/followNotification.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+
+const followNotificationSchema = new mongoose.Schema({
+    userId: {
+        type: mongoose.Schema.Types.ObjectId,
+        required: true,
+        ref: 'User',
+    },
+    otherUserId: {
+        type: mongoose.Schema.Types.ObjectId,
+        required: true,
+        ref: 'User',
+    }
+});
+
+const FollowNotification = mongoose.Model('FollowNotification', followNotificationSchema);
+module.exports = FollowNotification;

--- a/backend/models/followNotification.js
+++ b/backend/models/followNotification.js
@@ -1,12 +1,12 @@
 const mongoose = require('mongoose');
 
 const followNotificationSchema = new mongoose.Schema({
-    userId: {
+    follower: {
         type: mongoose.Schema.Types.ObjectId,
         required: true,
         ref: 'User',
     },
-    otherUserId: {
+    following: {
         type: mongoose.Schema.Types.ObjectId,
         required: true,
         ref: 'User',

--- a/backend/models/followNotification.js
+++ b/backend/models/followNotification.js
@@ -13,5 +13,5 @@ const followNotificationSchema = new mongoose.Schema({
     }
 });
 
-const FollowNotification = mongoose.Model('FollowNotification', followNotificationSchema);
+const FollowNotification = mongoose.model('FollowNotification', followNotificationSchema);
 module.exports = FollowNotification;

--- a/backend/routes/notification.js
+++ b/backend/routes/notification.js
@@ -7,11 +7,26 @@ const router = express.Router();
 
 router.get('/', isAuthenticated, async (req, res) => {
     try {
-        const userId =  req.token && req.token.data && req.token.data._id;
+        const userId = req.token && req.token.data && req.token.data._id;
         const response = await notificationService.getAll(userId);
         res.status(200).send(response);
     } catch (err) {
         res.status(500).send(errors.INTERNAL_ERROR(err));
+    }
+});
+
+router.post('/:id', isAuthenticated, async (req, res) => {
+    try {
+        const notificationId = req.params.id;
+        const userId = req.token && req.token.data && req.token.data._id;
+        await notificationService.discardNotification(notificationId, userId);
+        res.sendStatus(200);
+    } catch (err) {
+        if (err.name === 'NotificationNotFound') {
+            res.status(400).send(err);
+        } else {
+            res.status(500).send(errors.INTERNAL_ERROR(err));
+        }
     }
 });
 

--- a/backend/routes/notification.js
+++ b/backend/routes/notification.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const isAuthenticated = require('../middlewares/isAuthenticated');
+const notificationService = require('../services/notification');
+const errors = require('../helpers/errors');
+
+const router = express.Router();
+
+router.get('/', isAuthenticated, async (req, res) => {
+    try {
+        const userId =  req.token && req.token.data && req.token.data._id;
+        const response = await notificationService.getAll(userId);
+        res.status(200).send(response);
+    } catch (err) {
+        res.status(500).send(errors.INTERNAL_ERROR(err));
+    }
+});
+
+module.exports = router;

--- a/backend/routes/profile.js
+++ b/backend/routes/profile.js
@@ -7,6 +7,8 @@ const isAuthenticated = require('../middlewares/isAuthenticated');
 const errors = require('../helpers/errors');
 const jwt = require('jsonwebtoken');
 const moment = require('moment');
+const notificationService = require('../services/notification');
+
 const router = express.Router();
 
 function getTokenFromHeader(req) {
@@ -16,7 +18,7 @@ function getTokenFromHeader(req) {
         return req.query.token;
     }
     return null;
-};
+}
 
 const isInMyNetwork = (user,userToBeChecked) =>{
     const index = user.following.findIndex(elm => elm.userId._id.toString() === userToBeChecked._id.toString());
@@ -174,8 +176,9 @@ router.post('/other/:id/follow',isAuthenticated, async (req, res) => {
         const userId =  req.token && req.token.data && req.token.data._id;
         const user = await userService.getById(userId);
         const userToBeFollowed = await userService.getById(id);
-        res.status(200).json(await user.follow(userToBeFollowed));
-
+        const response = await user.follow(userToBeFollowed);
+        await notificationService.createFollowNotification(userId, id);
+        res.status(200).json(response);
     } catch (err) {
         if (err.name === 'UserNotFound') {
             res.status(400).send(err);
@@ -194,8 +197,9 @@ router.post('/other/:id/unfollow',isAuthenticated, async (req, res) => {
         const userId =  req.token && req.token.data && req.token.data._id;
         const user = await userService.getById(userId);
         const userToBeAccepted = await userService.getById(id);
-        res.status(200).json(await user.unfollow(userToBeAccepted));
-
+        const response = await user.unfollow(userToBeAccepted);
+        await notificationService.deleteFollowNotification(userId, id);
+        res.status(200).json(response);
     } catch (err) {
         if (err.name === 'UserNotFound') {
             res.status(400).send(err);
@@ -211,8 +215,9 @@ router.post('/other/:id/accept',isAuthenticated, async (req, res) => {
         const userId =  req.token && req.token.data && req.token.data._id;
         const user = await userService.getById(userId);
         const userToBeAccepted = await userService.getById(id);
-        res.status(200).json(await user.accept(userToBeAccepted));
-
+        const response = await user.accept(userToBeAccepted);
+        await notificationService.deleteFollowNotification(userId, id);
+        res.status(200).json(response);
     } catch (err) {
         if (err.name === 'UserNotFound') {
             res.status(400).send(err);
@@ -228,8 +233,9 @@ router.post('/other/:id/decline',isAuthenticated, async (req, res) => {
         const userId =  req.token && req.token.data && req.token.data._id;
         const user = await userService.getById(userId);
         const userToBeDeclined = await userService.getById(id);
-        res.status(200).json(await user.decline(userToBeDeclined));
-
+        const response = await user.decline(userToBeDeclined);
+        await notificationService.deleteFollowNotification(userId, id);
+        res.status(200).json(response);
     } catch (err) {
         if (err.name === 'UserNotFound') {
             res.status(400).send(err);

--- a/backend/routes/profile.js
+++ b/backend/routes/profile.js
@@ -216,7 +216,7 @@ router.post('/other/:id/accept',isAuthenticated, async (req, res) => {
         const user = await userService.getById(userId);
         const userToBeAccepted = await userService.getById(id);
         const response = await user.accept(userToBeAccepted);
-        await notificationService.deleteFollowNotification(userId, id);
+        await notificationService.deleteFollowNotification(id, userId);
         res.status(200).json(response);
     } catch (err) {
         if (err.name === 'UserNotFound') {
@@ -234,7 +234,7 @@ router.post('/other/:id/decline',isAuthenticated, async (req, res) => {
         const user = await userService.getById(userId);
         const userToBeDeclined = await userService.getById(id);
         const response = await user.decline(userToBeDeclined);
-        await notificationService.deleteFollowNotification(userId, id);
+        await notificationService.deleteFollowNotification(id, userId);
         res.status(200).json(response);
     } catch (err) {
         if (err.name === 'UserNotFound') {

--- a/backend/services/notification.js
+++ b/backend/services/notification.js
@@ -1,0 +1,9 @@
+const FollowNotification = require('../models/followNotification');
+
+module.exports.createFollowNotification = async (userId, otherUserId) => {
+    await FollowNotification.create({userId, otherUserId});
+};
+
+module.exports.deleteFollowNotification = async (userId, otherUserId) => {
+    await FollowNotification.deleteOne({userId, otherUserId});
+};

--- a/backend/services/notification.js
+++ b/backend/services/notification.js
@@ -1,9 +1,72 @@
 const FollowNotification = require('../models/followNotification');
 
-module.exports.createFollowNotification = async (userId, otherUserId) => {
-    await FollowNotification.create({userId, otherUserId});
+const STAGES = {
+    MATCH_ID: (userId) => {
+        return {
+            $match: {
+                $expr: {
+                    $eq: ['$following', {
+                        $toObjectId: userId
+                    }]
+                }
+            }
+        }
+    },
+    GET_FOLLOWER: {
+        $lookup: {
+            from: 'users',
+            let: {
+                follower: '$follower'
+            },
+            pipeline: [
+                {
+                    $match: {
+                        $expr: {
+                            $eq: ['$_id', '$$follower']
+                        }
+                    }
+                },
+                {
+                    $project: {
+                        _id: 1,
+                        name: 1,
+                        surname: 1,
+                    }
+                }
+            ],
+            as: 'follower'
+        }
+    },
+    UNWIND_FOLLOWER: {
+        $unwind: '$follower'
+    },
+    SET_TYPE: (type) => {
+        return {
+            $addFields: {
+                type
+            }
+        }
+    },
+    PROJECT_FOLLOW: {
+        $project: {
+            follower: 1,
+            type: 1,
+        }
+    }
 };
 
-module.exports.deleteFollowNotification = async (userId, otherUserId) => {
-    await FollowNotification.deleteOne({userId, otherUserId});
+
+module.exports.createFollowNotification = async (follower, following) => {
+    await FollowNotification.create({follower, following});
+};
+
+module.exports.deleteFollowNotification = async (follower, following) => {
+    await FollowNotification.deleteOne({follower, following});
+};
+
+module.exports.getAll = async (userId) => {
+    return await FollowNotification.aggregate([
+        STAGES.MATCH_ID(userId), STAGES.GET_FOLLOWER, STAGES.UNWIND_FOLLOWER,
+        STAGES.SET_TYPE('follow'), STAGES.PROJECT_FOLLOW
+    ]).then();
 };

--- a/backend/services/notification.js
+++ b/backend/services/notification.js
@@ -1,4 +1,5 @@
 const FollowNotification = require('../models/followNotification');
+const errors = require('../helpers/errors');
 
 const STAGES = {
     MATCH_ID: (userId) => {
@@ -55,7 +56,6 @@ const STAGES = {
     }
 };
 
-
 module.exports.createFollowNotification = async (follower, following) => {
     await FollowNotification.create({follower, following});
 };
@@ -69,4 +69,16 @@ module.exports.getAll = async (userId) => {
         STAGES.MATCH_ID(userId), STAGES.GET_FOLLOWER, STAGES.UNWIND_FOLLOWER,
         STAGES.SET_TYPE('follow'), STAGES.PROJECT_FOLLOW
     ]).then();
+};
+
+module.exports.discardNotification = async (notificationId, userId) => {
+  const followNotification = await FollowNotification.findOneAndDelete({
+      _id: notificationId,
+      following: userId,
+  });
+  if (followNotification) {
+      return;
+  }
+
+  throw errors.NOTIFICATION_NOT_FOUND();
 };

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "title": "Papel Backend"
   },
-  "host": "ec2-18-197-152-183.eu-central-1.compute.amazonaws.com:3000",
+  "host": "localhost:3000",
   "basePath": "/",
   "tags": [
     {

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -39,6 +39,10 @@
     {
       "name": "currency",
       "description": "Currency related endpoints."
+    },
+    {
+      "name": "notification",
+      "description": "Notification related endpoints."
     }
   ],
   "securityDefinitions": {
@@ -1423,7 +1427,6 @@
           {
             "Bearer": []
           }
-
         ],
         "summary": "Returns user's own profile",
         "consumes": [
@@ -1548,9 +1551,7 @@
             "description": "Internal error occurred. Check the cause field for the diagnostics."
           }
         }
-
       }
-
     },
     "/profile/other/{_id}/unfollow": {
       "post": {
@@ -1607,9 +1608,7 @@
             "description": "Internal error occurred. Check the cause field for the diagnostics."
           }
         }
-
       }
-
     },
     "/profile/other/{_id}/accept": {
       "post": {
@@ -1666,9 +1665,7 @@
             "description": "Internal error occurred. Check the cause field for the diagnostics."
           }
         }
-
       }
-
     },
     "/profile/other/{_id}/decline": {
       "post": {
@@ -2275,7 +2272,7 @@
       }
     },
     "/investments": {
-      "get":{
+      "get": {
         "tags": [
           "investments"
         ],
@@ -2297,11 +2294,10 @@
             "description": "Internal error occurred. Check the cause field for the diagnostics."
           }
         }
-
       }
     },
     "/investments/{_id}": {
-      "get":{
+      "get": {
         "tags": [
           "investments"
         ],
@@ -2332,7 +2328,34 @@
             "description": "Internal error occurred. Check the cause field for the diagnostics."
           }
         }
-
+      }
+    },
+    "/notification": {
+      "get": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "notification"
+        ],
+        "summary": "Endpoint to get all notifications for the user.",
+        "description": "The returned array contains all kinds of notifications of the given user. (follow, alert(not done yet) etc.) Each notification contains a type field. (follow, alert(not done yet) etc.) Other fields of array elements may differ depending on the type of the notification.",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. All the notifications related to the user is returned.",
+            "schema": {
+              "$ref": "#/definitions/Notification"
+            }
+          },
+          "500": {
+            "description": "Internal error occurred. Check the cause field for the diagnostics."
+          }
+        }
       }
     }
   },
@@ -2467,9 +2490,9 @@
         }
       }
     },
-    "CurrencyAmount":{
+    "CurrencyAmount": {
       "type": "object",
-      "properties":{
+      "properties": {
         "stock": {
           "$ref": "#/definitions/CurrencyMinimal"
         },
@@ -2480,9 +2503,9 @@
         }
       }
     },
-    "StockAmount":{
+    "StockAmount": {
       "type": "object",
-      "properties":{
+      "properties": {
         "stock": {
           "$ref": "#/definitions/Stock"
         },
@@ -3010,6 +3033,23 @@
           }
         }
       }
+    },
+    "Notification": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "example": [
+        {
+          "_id": "5de6c3e588aff72068fe72e8",
+          "follower": {
+            "_id": "5daeffa31b135672880aecb3",
+            "name": "John",
+            "surname": "Doe"
+          },
+          "type": "follow"
+        }
+      ]
     }
   }
 }

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "title": "Papel Backend"
   },
-  "host": "localhost:3000",
+  "host": "ec2-18-197-152-183.eu-central-1.compute.amazonaws.com:3000",
   "basePath": "/",
   "tags": [
     {
@@ -2351,6 +2351,39 @@
             "schema": {
               "$ref": "#/definitions/Notification"
             }
+          },
+          "500": {
+            "description": "Internal error occurred. Check the cause field for the diagnostics."
+          }
+        }
+      }
+    },
+    "/notification/{id}": {
+      "post": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "notification"
+        ],
+        "summary": "Endpoint to discard the given notification.",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "description": "Id of the notification.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. Notification successfully discarded."
           },
           "500": {
             "description": "Internal error occurred. Check the cause field for the diagnostics."


### PR DESCRIPTION
This PR adds the notification endpoint for backend.

With this feature, we will be able to send different notifications (follow, alert(not done yet)) to the users.

Users can check their notifications by making a get call to the endpoint. Then, they can act accordingly to the notification (For example, accept/reject follow request by making a call to their endpoints. Making these calls deletes the notification automatically.) Also, notifications can be discarded.