### PR TITLE
Cache stock prices

### DIFF
--- a/backend/models/stock.js
+++ b/backend/models/stock.js
@@ -9,20 +9,20 @@ const stockSchema = new mongoose.Schema({
         type: Number,
         required: true
     },
-
     monthlyPrice: {
-        type: Object
+        type: Object,
+        _id: false,
+        default: {}
     },
     dailyPrice: {
-        type: Object
+        type: Object,
+        _id: false,
+        default: {}
     },
     stockSymbol: {
         type: String,
         required: true
     },
-    stockName: {
-        type: String
-    }
 });
 
 module.exports = mongoose.model('Stock', stockSchema);

--- a/backend/routes/stock.js
+++ b/backend/routes/stock.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const stockService = require('../services/stock');
 const errors = require('../helpers/errors');
 const isAuthenticated = require('../middlewares/isAuthenticated');
+
 router.get('/', async (req, res) => {
     try {
         const response = await stockService.getAll();
@@ -26,15 +27,7 @@ router.get('/:id', async (req, res) => {
     }
 });
 
-router.post('/', async (req, res) => {
-    try {
-        const theStock = {...req.body};
-        const response = await stockService.create(theStock);
-        res.status(200).json(response);
-    } catch (e) {
-        res.status(503).json(e)
-    }
-});
+/*
 router.post('/:id/comment', isAuthenticated, async (req, res) => {
     try {
         const stockId = req.params.id;
@@ -130,5 +123,6 @@ router.delete('/:id/comment/:commentId', isAuthenticated, async (req, res) => {
         }
     }
 });
+*/
 
 module.exports = router;

--- a/backend/services/stock.js
+++ b/backend/services/stock.js
@@ -1,14 +1,8 @@
-const request = require('request-promise');
 const Stock = require('../models/stock');
 const errors = require('../helpers/errors');
 const StockComment = require('../models/stockComment');
 const mongoose = require('mongoose');
-const apiUrl = process.env.ALPHAVANTAGE_URL;
-const apiKeys = process.env.ALPHAVANTAGE_API_KEY;
-const apiKeyArr = apiKeys.split(',');
-const getRandomInt = (max) => {
-    return Math.floor(Math.random() * Math.floor(max));
-};
+
 const STAGES = {
     GET_COMMENTS: {
         $lookup: {
@@ -83,76 +77,23 @@ const STAGES = {
 
 };
 
-const getDailyPrice = async (symbol) => {
-    const rand = getRandomInt(apiKeyArr.length);
-    const apiKey = apiKeyArr[rand];
-    console.log(apiKey + " daily");
-    const dailyParams = {function: "TIME_SERIES_INTRADAY", symbol: symbol, interval: "5min", apikey: apiKey};
-    const options = {
-        uri: apiUrl,
-        qs: dailyParams
-    };
-    let response = await request.get(options);
-    response = JSON.parse(response);
-    if (response['Meta Data']) {
-        return response['Time Series (5min)'];
-    } else {
-        console.log("Error in daily Data")
-    }
-
-};
-
-
-const getMonthlyPrice = async (symbol) => {
-    const rand = getRandomInt(apiKeyArr.length);
-    const apiKey = apiKeyArr[rand];
-    console.log(apiKey + " monthly");
-    const dailyParams = {function: "TIME_SERIES_DAILY", symbol: symbol, apikey: apiKey};
-    const options = {
-        uri: apiUrl,
-        qs: dailyParams
-    };
-    let response = await request.get(options);
-    response = JSON.parse(response);
-    if (response['Meta Data']) {
-        return response['Time Series (Daily)'];
-    } else {
-        console.log("Error in Montly Data")
-    }
-
-};
-
-
 module.exports.getAll = async () => {
-    return await Stock.find();
+    return await Stock
+        .find()
+        .select("-monthlyPrice -dailyPrice")
+        .exec();
 };
 
 module.exports.getById = async (_id) => {
     if (!mongoose.Types.ObjectId.isValid(_id)) {
         throw errors.STOCK_NOT_FOUND();
     }
-    const stock = await Stock.aggregate([
-        STAGES.MATCH_ID(_id), STAGES.GET_COMMENTS
-    ]).then();
-    if (!stock) {
-        throw errors.STOCK_NOT_FOUND();
-    }
-    // Parallel API calls
-    const promises = [getDailyPrice(stock.stockSymbol), getMonthlyPrice(stock.stockSymbol)];
-    const resolves = await Promise.all(promises);
-    stock['dailyPrice'] = resolves[0];
-    stock['monthlyPrice'] = resolves[1];
-    return stock;
+    // TODO enabled comments
+    return Stock.findOne({_id});
 };
 
-module.exports.create = async (theStock) => {
-    const stock = {...theStock};
-    const createdStock = await Stock.create(stock);
-    return createdStock;
-};
-module.exports.delete = async (_id) => {
-    return await Stock.deleteOne({_id});
-};
+/*
+
 module.exports.postComment = async (stockId, authorId, body) => {
     if (!(mongoose.Types.ObjectId.isValid(stockId))) {
         throw errors.STOCK_NOT_FOUND();
@@ -215,3 +156,4 @@ module.exports.deleteComment = async (stockId, commentId, authorId) => {
         throw errors.COMMENT_NOT_FOUND();
     }
 };
+ */


### PR DESCRIPTION
With this PR, we would cache the stock prices (intraday with 5 minutes and daily with 24 hours intervals) so that we wouldn't make an api call to AlphaVantage each time. Also, the available stocks are lowered to 8 to satisfy the api key limits of AlphaVantage. Comments on stocks are disabled for now since they are not correctly implemented, I will be fixing it soon